### PR TITLE
Update Mullvad Config

### DIFF
--- a/scripts/net.rb
+++ b/scripts/net.rb
@@ -13,10 +13,8 @@ ca = File.read("../static/ca.crt")
 cfg = {
     ca: ca,
     cipher: "AES-256-CBC",
-    auth: "SHA1",
-    frame: 0,
     ping: 10,
-    reneg: 3600,
+    reneg: 0,
     eku: true
 }
 

--- a/scripts/net.rb
+++ b/scripts/net.rb
@@ -13,6 +13,8 @@ ca = File.read("../static/ca.crt")
 cfg = {
     ca: ca,
     cipher: "AES-256-CBC",
+    auth: "SHA1",
+    frame: 0,
     ping: 10,
     reneg: 0,
     eku: true


### PR DESCRIPTION
Mullvad’s config files have been updated and `auth` is no longer specified and compression framing isn’t either, so both can be removed. Additionally, `reneg-sec` was dropped down to zero, to disable it.